### PR TITLE
Implement traits for usize

### DIFF
--- a/xml_struct/src/impls.rs
+++ b/xml_struct/src/impls.rs
@@ -226,4 +226,4 @@ macro_rules! impl_as_text_for {
     };
 }
 
-impl_as_text_for!(i8, u8, i16, u16, i32, u32, i64, u64);
+impl_as_text_for!(i8, u8, i16, u16, i32, u32, i64, u64, usize);

--- a/xml_struct/src/tests.rs
+++ b/xml_struct/src/tests.rs
@@ -111,6 +111,13 @@ fn int_as_content_node() {
         actual, expected,
         "Serializing `u64` should result in bare text content"
     );
+
+    let actual =
+        serialize_value_children(content as usize).expect("Failed to serialize int as text content");
+    assert_eq!(
+        actual, expected,
+        "Serializing `usize` should result in bare text content"
+    );
 }
 
 #[test]
@@ -174,6 +181,13 @@ fn int_as_element() {
     assert_eq!(
         actual, expected,
         "Serializing `u64` should result in bare text content"
+    );
+
+    let actual = serialize_value_as_element(content as usize, name)
+        .expect("Failed to serialize int as text content");
+    assert_eq!(
+        actual, expected,
+        "Serializing `usize` should result in bare text content"
     );
 }
 

--- a/xml_struct/src/tests.rs
+++ b/xml_struct/src/tests.rs
@@ -112,8 +112,8 @@ fn int_as_content_node() {
         "Serializing `u64` should result in bare text content"
     );
 
-    let actual =
-        serialize_value_children(content as usize).expect("Failed to serialize int as text content");
+    let actual = serialize_value_children(content as usize)
+        .expect("Failed to serialize int as text content");
     assert_eq!(
         actual, expected,
         "Serializing `usize` should result in bare text content"


### PR DESCRIPTION
Prerequisite for serializing ews-rs's `Message` type through `XmlSerialize`.