### PR TITLE
Add a new error variant for pre-serialization formatting errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +201,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "xml_struct"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "quick-xml",
  "thiserror",
  "xml_struct_derive",

--- a/xml_struct/Cargo.toml
+++ b/xml_struct/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.69"
 quick-xml = "0.31.0"
 thiserror = "1.0.56"
 xml_struct_derive = { version = "0.1.0", path = "../xml_struct_derive" }

--- a/xml_struct/src/lib.rs
+++ b/xml_struct/src/lib.rs
@@ -139,5 +139,5 @@ pub enum Error {
     /// serializing it into XML. Its inner type is generic on purpose, as the
     /// specific error type might be defined by a third-party crate.
     #[error("unexpected error when formatting data structure prior to serialization")]
-    Format(#[from] anyhow::Error)
+    Format(#[from] anyhow::Error),
 }

--- a/xml_struct/src/lib.rs
+++ b/xml_struct/src/lib.rs
@@ -134,4 +134,10 @@ pub trait XmlSerializeAttr {
 pub enum Error {
     #[error("failed to process XML document")]
     Xml(#[from] quick_xml::Error),
+
+    /// An error representing a failure in formatting a data structure prior to
+    /// serializing it into XML. Its inner type is generic on purpose, as the
+    /// specific error type might be defined by a third-party crate.
+    #[error("unexpected error when formatting data structure prior to serialization")]
+    Format(#[from] anyhow::Error)
 }

--- a/xml_struct/src/lib.rs
+++ b/xml_struct/src/lib.rs
@@ -138,6 +138,6 @@ pub enum Error {
     /// An error representing a failure in formatting a data structure prior to
     /// serializing it into XML. Its inner type is generic on purpose, as the
     /// specific error type might be defined by a third-party crate.
-    #[error("failed to format a specific value")]
+    #[error("failed to serialize value as text")]
     Value(#[from] anyhow::Error),
 }

--- a/xml_struct/src/lib.rs
+++ b/xml_struct/src/lib.rs
@@ -138,6 +138,6 @@ pub enum Error {
     /// An error representing a failure in formatting a data structure prior to
     /// serializing it into XML. Its inner type is generic on purpose, as the
     /// specific error type might be defined by a third-party crate.
-    #[error("unexpected error when formatting data structure prior to serialization")]
-    Format(#[from] anyhow::Error),
+    #[error("failed to format a specific value")]
+    Value(#[from] anyhow::Error),
 }


### PR DESCRIPTION
Implementing XmlSerialize on some types might require handling errors when formatting them prior to serializing to XML. This change adds a new error variant to handle such errors, using anyhow to be flexible enough to handle errors from third-party crates without having to special-case each one we want to support going forwards.

This is a prerequisite for serializing ews-rs's `Message` type through `XmlSerialize`, more specifically for serializing `DateTime`. `time::OffsetDateTime::format(...)` can error with a `time::error::Format` (which can be turned into a `time::error::Error`, and be caught by `anyhow::Error`).